### PR TITLE
Fixes "Uncaught Error: Java bridge method can't be invoked on a non-injected object"  error in Android

### DIFF
--- a/android/src/main/java/com/shaynesweeney/react_native_webview_js_context/RNWebViewJSContextModule.java
+++ b/android/src/main/java/com/shaynesweeney/react_native_webview_js_context/RNWebViewJSContextModule.java
@@ -215,8 +215,8 @@ public class RNWebViewJSContextModule extends ReactContextBaseJavaModule {
 
         webView.evaluateJavascript(
                 "(function($w){" +
-                        "$w.resolve = $RNWebViewJSContext.global_resolver;" +
-                        "$w.reject = $RNWebViewJSContext.global_rejecter;" +
+                        "$w.resolve = $RNWebViewJSContext.global_resolver.bind($RNWebViewJSContext);" +
+                        "$w.reject = $RNWebViewJSContext.global_rejecter.bind($RNWebViewJSContext);" +
                         "})(window);", null);
 
 


### PR DESCRIPTION
The JS function context of "this" is not carried over when assigning $RNWebViewJSContext.global_resolver to window.resolve.  The $RNWebViewJSContext needs to be explicitly bound .
